### PR TITLE
[foilpics] Add German translation

### DIFF
--- a/translations/harbour-foilpics-de.ts
+++ b/translations/harbour-foilpics-de.ts
@@ -1,0 +1,351 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de">
+<context>
+    <name></name>
+    <message id="foilpics-app_name">
+        <source>Foil Pics</source>
+        <extracomment>Application title</extracomment>
+        <translation>Foil Pics</translation>
+    </message>
+    <message id="foilpics-menu-details">
+        <source>Image details</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Bilddetails</translation>
+    </message>
+    <message id="foilpics-menu-encrypt">
+        <source>Encrypt</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Verschlüsseln</translation>
+    </message>
+    <message id="foilpics-menu-decrypt">
+        <source>Decrypt</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Entschlüsseln</translation>
+    </message>
+    <message id="foilpics-menu-delete">
+        <source>Delete</source>
+        <extracomment>Generic menu item</extracomment>
+        <translation>Löschen</translation>
+    </message>
+    <message id="foilpics-pulley_menu-generate_key">
+        <source>Generate a new key</source>
+        <extracomment>Pulley menu item</extracomment>
+        <translation>Neuen Schlüssel erstellen</translation>
+    </message>
+    <message id="foilpics-pulley_menu-change_password">
+        <source>Change password</source>
+        <extracomment>Pulley menu item</extracomment>
+        <translation>Passwort ändern</translation>
+    </message>
+    <message id="foilpics-pulley_menu-decrypt_all">
+        <source>Decrypt all</source>
+        <extracomment>Pulley menu item</extracomment>
+        <translation>Alles entschlüsseln</translation>
+    </message>
+    <message id="foilpics-pulley_menu-remorse-decrypting_all">
+        <source>Decrypting all pictures</source>
+        <extracomment>Decrypting all pictures in 5 seconds</extracomment>
+        <translation>Alle Bilder entschlüsseln</translation>
+    </message>
+    <message id="foilpics-file_size-bytes">
+        <source>%n B</source>
+        <translation>%n B</translation>
+    </message>
+    <message id="foilpics-file_size-kilobytes">
+        <source>%1 kB</source>
+        <translation>%1 kB</translation>
+    </message>
+    <message id="foilpics-file_size-megabytes">
+        <source>%1 MB</source>
+        <translation>%1 MB</translation>
+    </message>
+    <message id="foilpics-file_size-gigabytes">
+        <source>%1 GB</source>
+        <translation>%1 GB</translation>
+    </message>
+    <message id="foilpics-file_size-terabytes">
+        <source>%1 TB</source>
+        <translation>%1 TB</translation>
+    </message>
+    <message id="foilpics-notification-generated_key">
+        <source>Generated new key</source>
+        <extracomment>Pop-up notification</extracomment>
+        <translation>Neuen Schlüssel generieren</translation>
+    </message>
+    <message id="foilpics-notification-password_changed">
+        <source>Password changed</source>
+        <extracomment>Pop-up notification</extracomment>
+        <translation>Passwort änderen</translation>
+    </message>
+    <message id="foilpics-hint-swipe_left_to_gallery">
+        <source>Swipe left to access the picture gallery</source>
+        <extracomment>Left swipe hint text</extracomment>
+        <translation>Wische nach links um die Galerie zu öffnen</translation>
+    </message>
+    <message id="foilpics-hint-swipe_right_to_encrypted">
+        <source>Encrypted pictures are moved there to the left</source>
+        <extracomment>Right swipe hint text</extracomment>
+        <translation>Verschlüsselte Bilder sind nach Links verschoben</translation>
+    </message>
+    <message id="foilpics-hint-swipe_left_to_decrypted">
+        <source>Decrypted pictures are moved back to the gallery</source>
+        <extracomment>Left swipe hint text</extracomment>
+        <translation>Entschlüsselte Bilder werden zurück in die Galerie verschoben</translation>
+    </message>
+    <message id="foilpics-generate_key_warning-title">
+        <source>Warning</source>
+        <extracomment>Title for the new key warning</extracomment>
+        <translation>Warnung</translation>
+    </message>
+    <message id="foilpics-generate_key_warning-text">
+        <source>You seem to have some encrypted files in the storage folder. Once you have generated a new key, you are going to lose access to those files. If you have forgotten your password, then keep in mind that most likely it&apos;s computationally easier to brute-force your password and recover the old key than to crack the new key.</source>
+        <extracomment>Warning shown prior to generating the new key</extracomment>
+        <translation>Du hast ein paar verschlüsselte Dateien. Mit dem erstellen eines neuen Schlüssels verlierst du den Zugriff auf diese Dateien. Wenn du dein Passwort vergessen hast, wird es leichter sein mittels Brute-Force dein Passwort zu ermitteln und den alten Schlüssel wiederherzustellen als den neuen Schlüssel zu cracken.</translation>
+    </message>
+    <message id="foilpics-generate_key_page-title">
+        <source>You are about to generate a new key</source>
+        <extracomment>Label text</extracomment>
+        <translation>Du bist dabei einen neuen Schlüssel zu erstellen</translation>
+    </message>
+    <message id="foilpics-generating_key_view-generating_new_key">
+        <source>Generating new key...</source>
+        <extracomment>Progress view label</extracomment>
+        <translation>Generiere neuen Schlüssel...</translation>
+    </message>
+    <message id="foilpics-generate_key_view-label-key_needed">
+        <source>You need to generate the key and select the password before you can encrypt your pictures</source>
+        <extracomment>Label text</extracomment>
+        <translation>Du musst ein Schlüssel und ein Passwort erstellen, um Bilder zu verschlüsseln.</translation>
+    </message>
+    <message id="foilpics-generate_key_view-label-key_size">
+        <source>Key size</source>
+        <extracomment>Combo box label</extracomment>
+        <translation>Schlüsselgröße</translation>
+    </message>
+    <message id="foilpics-generate_key_view-label-minimum_length" numerus="yes">
+        <source>Type at least %0 character(s)</source>
+        <extracomment>Password field label</extracomment>
+        <translation> 
+            <numerusform>Nutze mindestens %0 Zeichen</numerusform>
+            <numerusform>Nutze mindestens %0 Zeichen</numerusform>
+        </translation>
+    </message>
+    <message id="foilpics-generate_key_view-button-generate_key">
+        <source>Generate key</source>
+        <extracomment>Button label</extracomment>
+        <translation>Schlüssel generieren</translation>
+    </message>
+    <message id="foilpics-generate_key_view-button-generating_key">
+        <source>Generating...</source>
+        <extracomment>Button label</extracomment>
+        <translation>Generiere...</translation>
+    </message>
+    <message id="foilpics-enter_password_view-label-enter_password">
+        <source>Secret pictures are locked. Please enter your password</source>
+        <extracomment>Password prompt label</extracomment>
+        <translation>Deine geheimen Bilder sind gesperrt. Entsperre Sie mit deinem Passwort</translation>
+    </message>
+    <message id="foilpics-enter_password_view-button-unlocking">
+        <source>Unlocking...</source>
+        <extracomment>Button label</extracomment>
+        <translation>Entsperren...</translation>
+    </message>
+    <message id="foilpics-enter_password_view-button-unlock">
+        <source>Unlock</source>
+        <extracomment>Button label</extracomment>
+        <translation>Entsperrt</translation>
+    </message>
+    <message id="foilpics-change_password_page-label-enter_passwords">
+        <source>Please enter the current and the new password</source>
+        <extracomment>Password change prompt</extracomment>
+        <translation>Please enter the current and the new password</translation>
+        <translation>Bitte gib dein derzeitiges und neues Passwort ein.</translation>
+    </message>
+    <message id="foilpics-change_password_page-text_field_label-current_password">
+        <source>Current password</source>
+        <extracomment>Placeholder and label for the current password prompt</extracomment>
+        <translation>Derzeitiges Passwort</translation>
+    </message>
+    <message id="foilpics-change_password_page-text_field_label-new_password">
+        <source>New password</source>
+        <extracomment>Placeholder and label for the new password prompt</extracomment>
+        <translation>Neues Passwort</translation>
+    </message>
+    <message id="foilpics-change_password_page-button-change_password">
+        <source>Change password</source>
+        <extracomment>Button label</extracomment>
+        <translation>Passwort ändern</translation>
+    </message>
+    <message id="foilpics-decrypting_view-unlocking">
+        <source>Unlocking...</source>
+        <extracomment>Progress view label</extracomment>
+        <translation>Entsperren...</translation>
+    </message>
+    <message id="foilpics-decrypting_view-decrypting">
+        <source>Decrypting...</source>
+        <extracomment>Progress view label</extracomment>
+        <translation>Entschlüsseln...</translation>
+    </message>
+    <message id="foilpics-image_grid_view-remorse-deleting">
+        <source>Deleting</source>
+        <extracomment>Deleting image in 5 seconds</extracomment>
+        <translation>Löschen</translation>
+    </message>
+    <message id="foilpics-image_grid_view-remorse-cancel_deletion">
+        <source>Cancel</source>
+        <extracomment>RemorseItem cancel help text</extracomment>
+        <translation>Abbrechen</translation>
+    </message>
+    <message id="foilpics-gallery_grid-title">
+        <source>Photos</source>
+        <extracomment>Gallery grid title</extracomment>
+        <translation>Bilder</translation>
+    </message>
+    <message id="foilpics-gallery_view-placeholder-no_pictures">
+        <source>The photo gallery seems to be empty</source>
+        <extracomment>Placeholder text</extracomment>
+        <translation>Deine Bildergalerie ist leer.</translation>
+    </message>
+    <message id="foilpics-gallery_fullscreen_view-header">
+        <source>Share</source>
+        <extracomment>Page header</extracomment>
+        <translation>Teile</translation>
+    </message>
+    <message id="foilpics-encrypted_grid-title">
+        <source>Encrypted</source>
+        <extracomment>Encrypted grid title</extracomment>
+        <translation>Verschlüsselt</translation>
+    </message>
+    <message id="foilpics-thumbnail_image-loading_failed">
+        <source>Oops, can&apos;t display the thumbnail!</source>
+        <extracomment>Thumbnail Image loading failed</extracomment>
+        <translation>Miniaturansicht kann nicht angezeigt werden!</translation>
+    </message>
+    <message id="foilpics-share_method_list-add_account">
+        <source>Add account</source>
+        <extracomment>Share list item</extracomment>
+        <translation>Konto hinzufügen</translation>
+    </message>
+    <message id="foilpics-encrypted_grid-remorse-cancel_decrypt">
+        <source>Cancel</source>
+        <extracomment>RemorseItem cancel help text</extracomment>
+        <translation>Abbrechen</translation>
+    </message>
+    <message id="foilpics-encrypted_grid-placeholder-no_pictures_hint">
+        <source>Why not to encrypt something?</source>
+        <extracomment>Placeholder text with a hint</extracomment>
+        <translation>Willst du nicht etwas verschlüsseln?</translation>
+    </message>
+    <message id="foilpics-encrypted_grid-placeholder-no_pictures">
+        <source>You don&apos;t have any encrypted pictures</source>
+        <extracomment>Placeholder text</extracomment>
+        <translation>Du hast keine verschlüsselten Bilder</translation>
+    </message>
+    <message id="foilpics-encrypted_grid-remorse-decrypting">
+        <source>Decrypting</source>
+        <extracomment>Decrypting image in 5 seconds</extracomment>
+        <translation>Entschlüsseln</translation>
+    </message>
+    <message id="foilpics-confirm_password_page-info_label">
+        <source>Please type in your new password one more time</source>
+        <extracomment>Password confirmation label</extracomment>
+        <translation>Bitte gib dein neues Passwort ein weiteres mal ein</translation>
+    </message>
+    <message id="foilpics-confirm_password_page-description">
+        <source>Make sure you don&apos;t forget your password. It&apos;s impossible to either recover it or to access the encrypted pictures without knowing it. Better take it seriously.</source>
+        <extracomment>Password confirmation description</extracomment>
+        <translation>Stell sicher, dass du dein Passwort nicht vergisst.Es ist unmöglich es wiederherszustellen noch deine verschlüsselten Bilder zu öffnen.</translation>
+    </message>
+    <message id="foilpics-confirm_password_page-text_field_placeholder-new_password">
+        <source>New password again</source>
+        <extracomment>Placeholder for the password confirmation prompt</extracomment>
+        <translation>Neues Passwort wiederholen</translation>
+    </message>
+    <message id="foilpics-confirm_password_page-text_field_label-new_password">
+        <source>New password</source>
+        <extracomment>Label for the password confirmation prompt</extracomment>
+        <translation>Neues Passwort</translation>
+    </message>
+    <message id="foilpics-confirm_password_page-button-confirm">
+        <source>Confirm</source>
+        <extracomment>Button label (confirm password)</extracomment>
+        <translation>Bestätigen</translation>
+    </message>
+    <message id="foilpics-details-header">
+        <source>Details</source>
+        <extracomment>Page header</extracomment>
+        <translation>Details</translation>
+    </message>
+    <message id="foilpics-details-file_name-label">
+        <source>File name</source>
+        <extracomment>Details label</extracomment>
+        <translation>Dateiname</translation>
+    </message>
+    <message id="foilpics-details-file_size-label">
+        <source>File size</source>
+        <extracomment>Details label</extracomment>
+        <translation>Dateigröße</translation>
+    </message>
+    <message id="foilpics-details-original_file_size-label">
+        <source>Original file size</source>
+        <extracomment>Details label</extracomment>
+        <translation>Orginal Dateigröße</translation>
+    </message>
+    <message id="foilpics-details-encrypted_file_size-label">
+        <source>Encrypted file size</source>
+        <extracomment>Details label</extracomment>
+        <translation>Verschlüsselte Dateigröße</translation>
+    </message>
+    <message id="foilpics-details-mime_type-label">
+        <source>Type</source>
+        <extracomment>Details label</extracomment>
+        <translation>Art</translation>
+    </message>
+    <message id="foilpics-details-width-label">
+        <source>Width</source>
+        <extracomment>Details label</extracomment>
+        <translation>Breit</translation>
+    </message>
+    <message id="foilpics-details-height-label">
+        <source>Height</source>
+        <extracomment>Details label</extracomment>
+        <translation>Hoch</translation>
+    </message>
+    <message id="foilpics-details-date-label">
+        <source>Date</source>
+        <extracomment>Details label</extracomment>
+        <translation>Datum</translation>
+    </message>
+    <message id="foilpics-details-camera_manufacturer-label">
+        <source>Camera manufacturer</source>
+        <extracomment>Details label</extracomment>
+        <translation>Kamera Hersteller</translation>
+    </message>
+    <message id="foilpics-details-camera_model-label">
+        <source>Camera model</source>
+        <extracomment>Details label</extracomment>
+        <translation>Kamera Model</translation>
+    </message>
+    <message id="foilpics-details-coordinates-label">
+        <source>Coordinates</source>
+        <extracomment>Details label</extracomment>
+        <translation>Standort</translation>
+    </message>
+    <message id="foilpics-details-coordinates-value">
+        <source>Latitude %1, Longitude %2, Altitude %3</source>
+        <extracomment>Coordinates</extracomment>
+        <translation>Breitengrad %1, Längengrad %2, Höhe %3</translation>
+    </message>
+    <message id="foilpics-details-section_header-editable">
+        <source>Editable details</source>
+        <extracomment>Section header for editable details</extracomment>
+        <translation>Editierbar Details</translation>
+    </message>
+    <message id="foilpics-details-image_title-label">
+        <source>Title</source>
+        <extracomment>Details label</extracomment>
+        <translation>Titel</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
German translation for Foilpics

Maybe @Wunderfitz likes to review before merging typos or misleading translations   

In [line 127](https://github.com/Nokius/harbour-foilpics/commit/299e42e0ef9894a6dd623c0facb7ddd07a6173a4#diff-3843646b3e3834f5d17b8648f8c608beR127) I removed the numerusform as the German word [Zeichen](https://www.duden.de/suchen/dudenonline/Zeichen) isn't changing in Plural.  